### PR TITLE
feature: ServiceStack v5 compatibilty

### DIFF
--- a/src/IdentityServer3.Contrib.ServiceStack/IdentityServer3.Contrib.ServiceStack.csproj
+++ b/src/IdentityServer3.Contrib.ServiceStack/IdentityServer3.Contrib.ServiceStack.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <Description>An IdentityServer plugin for ServiceStack Authentication</Description>
     <Copyright>Copyright © 2016</Copyright>
     <AssemblyTitle>ServiceStack.IdentityServer.Provider</AssemblyTitle>

--- a/src/IdentityServer4.Contrib.ServiceStack/IdentityServer4.Contrib.ServiceStack.csproj
+++ b/src/IdentityServer4.Contrib.ServiceStack/IdentityServer4.Contrib.ServiceStack.csproj
@@ -4,7 +4,7 @@
     <Description>An IdentityServer plugin for ServiceStack Authentication</Description>
     <VersionPrefix>4.0.0</VersionPrefix>
     <Authors>Stuart Banks;Scott Mackay</Authors>
-    <TargetFrameworks>netstandard1.4;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -21,12 +21,12 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All"/>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/src/ServiceStack.Authentication.IdentityServer/Clients/DocumentDiscoveryClient.cs
+++ b/src/ServiceStack.Authentication.IdentityServer/Clients/DocumentDiscoveryClient.cs
@@ -24,7 +24,6 @@ namespace ServiceStack.Authentication.IdentityServer.Clients
         {
             IJsonServiceClient client = new JsonServiceClient(appSettings.AuthRealm);
 
-#if NETSTANDARD1_6
             string document;
             try
             {
@@ -41,25 +40,6 @@ namespace ServiceStack.Authentication.IdentityServer.Clients
             }
 
             var configuration = new Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectConfiguration(document);
-#elif NET45
-            Dictionary<string, object> document;            
-            try
-            {
-                document = await client.GetAsync<Dictionary<string, object>>(endpoint)
-                                       .ConfigureAwait(false);
-            }
-            catch (AggregateException exception)
-            {
-                foreach (var ex in exception.InnerExceptions)
-                {
-                    Log.Error($"Error occurred requesting document data from {endpoint}", ex);
-                }
-                return null;
-            }
-            
-            var configuration = new Microsoft.IdentityModel.Protocols.OpenIdConnectConfiguration(document);
-#endif
-
             return new DocumentDiscoveryResult
             {
                 AuthorizeUrl = configuration.AuthorizationEndpoint,

--- a/src/ServiceStack.Authentication.IdentityServer/Clients/JsonWebKeyClient.cs
+++ b/src/ServiceStack.Authentication.IdentityServer/Clients/JsonWebKeyClient.cs
@@ -20,11 +20,7 @@ namespace ServiceStack.Authentication.IdentityServer.Clients
             appSettings = settings;
         }
 
-#if NETSTANDARD1_6
         public async Task<IList<Microsoft.IdentityModel.Tokens.SecurityKey>> GetAsync()
-#elif NET45
-        public async Task<IList<System.IdentityModel.Tokens.SecurityToken>> GetAsync()
-#endif
         {
             var httpClient = new JsonServiceClient();
 
@@ -44,13 +40,9 @@ namespace ServiceStack.Authentication.IdentityServer.Clients
                 return null;
             }
 
-#if NETSTANDARD1_6
+
             var webKeySet = new Microsoft.IdentityModel.Tokens.JsonWebKeySet(document);
-            return webKeySet.GetSigningKeys();
-#elif NET45
-            var webKeySet = new Microsoft.IdentityModel.Protocols.JsonWebKeySet(document);
-            return webKeySet.GetSigningTokens();  
-#endif                   
+            return webKeySet.GetSigningKeys();                   
         }
     }
 }

--- a/src/ServiceStack.Authentication.IdentityServer/Clients/UserInfoClient.cs
+++ b/src/ServiceStack.Authentication.IdentityServer/Clients/UserInfoClient.cs
@@ -24,7 +24,6 @@ namespace ServiceStack.Authentication.IdentityServer.Clients
 
         public async Task<IEnumerable<Claim>> GetClaims(string accessToken)
         {
-#if NETSTANDARD1_6
             var client = new IdentityModel.Client.UserInfoClient(appSettings.UserInfoUrl);
             var response = await client.GetAsync(accessToken).ConfigureAwait(false);
             if (response.IsError)
@@ -33,15 +32,6 @@ namespace ServiceStack.Authentication.IdentityServer.Clients
             }
 
             return response.Claims.Select(x => new Claim(x.Type, x.Value));
-#elif NET45
-            var client = new IdentityModel.Client.UserInfoClient(new Uri(appSettings.UserInfoUrl), accessToken);
-            var response = await client.GetAsync().ConfigureAwait(false);
-            if (response.IsError)
-            {
-                Log.Error($"Error calling endpoint {appSettings.UserInfoUrl} - {response.ErrorMessage}");
-            }
-            return response.Claims.Select(x => new Claim(x.Item1, x.Item2));
-#endif
         }
     }
 }

--- a/src/ServiceStack.Authentication.IdentityServer/IdentityServerAuthFeature.cs
+++ b/src/ServiceStack.Authentication.IdentityServer/IdentityServerAuthFeature.cs
@@ -126,11 +126,7 @@ namespace ServiceStack.Authentication.IdentityServer
                 return;
             }
 
-#if NETSTANDARD1_6
             var authTokens = session.GetAuthTokens(IdentityServerAuthProvider.Name);
-#elif NET45
-            var authTokens = session.GetOAuthTokens(IdentityServerAuthProvider.Name);
-#endif            
             if (string.IsNullOrEmpty(authTokens?.AccessToken))
             {
                 return;

--- a/src/ServiceStack.Authentication.IdentityServer/IdentityServerIdTokenValidator.cs
+++ b/src/ServiceStack.Authentication.IdentityServer/IdentityServerIdTokenValidator.cs
@@ -12,8 +12,6 @@ namespace ServiceStack.Authentication.IdentityServer
     using Interfaces;
     using Logging;
 
-#if NETSTANDARD1_6    
-
     using System.IdentityModel.Tokens.Jwt;
     using IdentityModel;
     using Microsoft.IdentityModel.Tokens;
@@ -111,104 +109,4 @@ namespace ServiceStack.Authentication.IdentityServer
             return true;
         }
     }
-
-#elif NET45
-
-    using System.IdentityModel.Tokens;
-    using IdentityModel;
-
-    class IdentityServerIdTokenValidator : IIdentityServerIdTokenValidator
-    {
-        private static readonly ILog Log = LogManager.GetLogger(typeof(IdentityServerIdTokenValidator));
-
-        private readonly IIdentityServerAuthProviderSettings appSettings;
-        private readonly TokenValidationParameters tokenValidationParameters;
-
-        public IdentityServerIdTokenValidator(IIdentityServerAuthProviderSettings settings)
-        {
-            this.appSettings = settings;
-            tokenValidationParameters = new TokenValidationParameters();
-        }
-
-        internal ISecurityTokenValidator SecurityTokenValidator { get; set; }
-
-        internal IJsonWebKeyClient JsonWebKeyClient { get; set; }
-
-        public async Task Init()
-        {
-            if (SecurityTokenValidator == null)
-            {
-                SecurityTokenValidator = new JwtSecurityTokenHandler();
-            }
-
-            if (JsonWebKeyClient == null)
-            {
-                JsonWebKeyClient = new JsonWebKeyClient(appSettings);
-            }
-
-            var tokens = await JsonWebKeyClient.GetAsync();
-
-            if (tokens == null || tokens.Count == 0)
-            {
-                Log.Warn($"Unable to load Json Web Kit Set from {appSettings.JwksUrl}");
-            }
-            else
-            {
-                tokenValidationParameters.IssuerSigningTokens = tokens;
-            }
-
-            tokenValidationParameters.ValidAudience = appSettings.ClientId;
-
-            var realms = new string[2];
-            var realm = appSettings.AuthRealm;
-            realms[0] = realm.EndsWith("/") ? realm.TrimEnd('/') : $"{realm}/";
-            realms[1] = realm;
-
-            tokenValidationParameters.ValidIssuers = realms;
-        }
-
-        public bool IsValidIdToken(IAuthTokens authTokens, string idToken)
-        {
-            var jwtToken = new JwtSecurityToken(idToken);
-
-            var idAuthTokens = authTokens as IdentityServerAuthTokens;
-            if (idAuthTokens != null)
-            {
-                var nonce = jwtToken.Claims.FirstOrDefault(x => x.Type == JwtClaimTypes.Nonce);
-                if (nonce != null && nonce.Value != idAuthTokens.Nonce)
-                {
-                    Log.Error("Nonce in id_token does not match the nonce created for the login request - potential replay attack");
-                    return false;
-                }
-            }
-
-            SecurityToken validatedToken = null;
-
-            try
-            {
-                SecurityTokenValidator.ValidateToken(idToken, tokenValidationParameters, out validatedToken);
-            }
-            catch (Exception exception)
-            {
-                Log.Error("Error validating JWT token", exception);
-                return false;
-            }
-
-            if (validatedToken == null)
-            {
-                Log.Error("Unable to validate id_token");
-                return false;
-            }
-
-            var jwt = validatedToken as JwtSecurityToken;
-            if (jwt == null)
-            {
-                Log.Error("id_token is not a valid jwt token");
-                return false;
-            }
-
-            return true;
-        }
-    }
-#endif
 }

--- a/src/ServiceStack.Authentication.IdentityServer/Interfaces/IJsonWebKeyClient.cs
+++ b/src/ServiceStack.Authentication.IdentityServer/Interfaces/IJsonWebKeyClient.cs
@@ -8,10 +8,6 @@ namespace ServiceStack.Authentication.IdentityServer.Interfaces
 
     public interface IJsonWebKeyClient
     {
-#if NETSTANDARD1_6
         Task<IList<Microsoft.IdentityModel.Tokens.SecurityKey>> GetAsync();
-#elif NET45
-        Task<IList<System.IdentityModel.Tokens.SecurityToken>> GetAsync();
-#endif
     }
 }

--- a/src/ServiceStack.Authentication.IdentityServer/Providers/UserAuthProvider.cs
+++ b/src/ServiceStack.Authentication.IdentityServer/Providers/UserAuthProvider.cs
@@ -205,7 +205,6 @@ namespace ServiceStack.Authentication.IdentityServer.Providers
             {
                 return true;
             }
-#if NETSTANDARD1_6
 
             if (httpRequest.UrlReferrer == null) return false;
 
@@ -213,11 +212,6 @@ namespace ServiceStack.Authentication.IdentityServer.Providers
             var authRealm = new Uri(AuthRealm);
 
             return referrer.AbsoluteUri.IndexOf(authRealm.AbsoluteUri, StringComparison.OrdinalIgnoreCase) == 0;
-
-#elif NET45
-            return httpRequest.UrlReferrer != null && 
-                   httpRequest.UrlReferrer.AbsoluteUri.IndexOf(AuthRealm, StringComparison.InvariantCultureIgnoreCase) == 0;
-#endif
         }
 
         /// <summary>Authenticates the Client by Redirecting them to the Authorize Url Endpoint of Identity Server</summary>
@@ -340,12 +334,7 @@ namespace ServiceStack.Authentication.IdentityServer.Providers
             var idAuthTokens = tokens as IdentityServerAuthTokens;
             if (!string.IsNullOrWhiteSpace(idAuthTokens?.IdToken))
             {
-#if NETSTANDARD1_6
-
                 var jwtToken = new System.IdentityModel.Tokens.Jwt.JwtSecurityToken(idAuthTokens.IdToken);
-#elif NET45
-                var jwtToken = new System.IdentityModel.Tokens.JwtSecurityToken(idAuthTokens.IdToken);
-#endif
                 idAuthTokens.Issuer = jwtToken.Issuer;
                 idAuthTokens.Subject = jwtToken.Subject;
 

--- a/src/ServiceStack.Authentication.IdentityServer/ServiceStack.Authentication.IdentityServer.csproj
+++ b/src/ServiceStack.Authentication.IdentityServer/ServiceStack.Authentication.IdentityServer.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>A ServiceStack plugin for IdentityServer.</Description>
     <Authors>Stuart Banks;Scott Mackay</Authors>
-    <TargetFrameworks>netstandard1.6;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseUrl>https://www.mozilla.org/en-US/MPL/2.0/</PackageLicenseUrl>
@@ -12,28 +12,21 @@
     <PackageReleaseNotes>https://github.com/wwwlicious/servicestack-authentication-identityserver/releases</PackageReleaseNotes>
     <PackageIconUrl>https://servicestack.net/img/logo-32.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/wwwlicious/servicestack-authentication-identityserver</PackageProjectUrl>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
-    <PackageReference Include="ServiceStack.Core" Version="1.0.33" />
-    <PackageReference Include="IdentityModel" Version="2.5.1" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="2.1.2" />
-  </ItemGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <DefineConstants>$(DefineConstants);NET45</DefineConstants>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">
+    <DefineConstants>$(DefineConstants);NET462</DefineConstants>
   </PropertyGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <PackageReference Include="IdentityModel" Version="1.11.0" />
-    <PackageReference Include="ServiceStack" Version="4.0.56" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocol.Extensions" Version="1.0.2.206221351" />
+  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net463' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="ServiceStack" Version="5.4.0" />
+    <PackageReference Include="IdentityModel" Version="2.5.1" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="2.1.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All"/>
   </ItemGroup>
 

--- a/src/samples/IdentityServer3.SelfHost/IdentityServer3.SelfHost.csproj
+++ b/src/samples/IdentityServer3.SelfHost/IdentityServer3.SelfHost.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/samples/IdentityServer4.SelfHost/IdentityServer4.SelfHost.csproj
+++ b/src/samples/IdentityServer4.SelfHost/IdentityServer4.SelfHost.csproj
@@ -1,12 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>IdentityServer4.SelfHost</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>IdentityServer4.SelfHost</PackageId>
-    <RuntimeFrameworkVersion>1.1.1</RuntimeFrameworkVersion>
     <PackageTargetFallback>$(PackageTargetFallback);dotnet5.6;portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 

--- a/src/samples/ImpersonateAuthProvider.ServiceStack.Api.SelfHost/ImpersonateAuthProvider.ServiceStack.Api.SelfHost.csproj
+++ b/src/samples/ImpersonateAuthProvider.ServiceStack.Api.SelfHost/ImpersonateAuthProvider.ServiceStack.Api.SelfHost.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/samples/ImpersonateAuthProvider.ServiceStack.Api.SelfHost/ServiceInterface/ExternalServices.cs
+++ b/src/samples/ImpersonateAuthProvider.ServiceStack.Api.SelfHost/ServiceInterface/ExternalServices.cs
@@ -11,7 +11,7 @@
         {
             var session = this.GetSession();
 
-            if (session.HasPermission("CanSeeAllOrders"))
+            if (session.HasPermission( "CanSeeAllOrders", null))
             {
                 return new HelloResponse
                 {

--- a/src/samples/ImpersonateAuthProvider.ServiceStack.Api.SelfHost/ServiceInterface/MyServices.cs
+++ b/src/samples/ImpersonateAuthProvider.ServiceStack.Api.SelfHost/ServiceInterface/MyServices.cs
@@ -14,7 +14,7 @@ namespace ImpersonateAuthProvider.ServiceStack.Api.SelfHost.ServiceInterface
         {
             var session = this.GetSession();
 
-            if (session.HasPermission("CanSeeAllOrders"))
+            if (session.HasPermission("CanSeeAllOrders", null))
             {
                 return new HelloResponse
                 {

--- a/src/samples/ImpersonateAuthProvider.ServiceStack.SelfHost/ImpersonateAuthProvider.ServiceStack.SelfHost.csproj
+++ b/src/samples/ImpersonateAuthProvider.ServiceStack.SelfHost/ImpersonateAuthProvider.ServiceStack.SelfHost.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net45</TargetFramework>
+        <TargetFramework>net462</TargetFramework>
         <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
@@ -16,6 +16,6 @@
         </Content>
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="ServiceStack.Razor" Version="4.0.56" />
+      <PackageReference Include="ServiceStack.Razor" Version="5.4.0" />
     </ItemGroup>
 </Project>

--- a/src/samples/ServiceAuthProvider.ServiceStack.Api.SelfHost/ServiceAuthProvider.ServiceStack.Api.SelfHost.csproj
+++ b/src/samples/ServiceAuthProvider.ServiceStack.Api.SelfHost/ServiceAuthProvider.ServiceStack.Api.SelfHost.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net45</TargetFramework>
+        <TargetFramework>net462</TargetFramework>
         <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>

--- a/src/samples/ServiceAuthProvider.ServiceStack.Api.SelfHost/ServiceInterface/ExternalServices.cs
+++ b/src/samples/ServiceAuthProvider.ServiceStack.Api.SelfHost/ServiceInterface/ExternalServices.cs
@@ -11,7 +11,7 @@
         {
             var session = this.GetSession();
 
-            if (session.HasPermission("CanSeeAllOrders"))
+            if (session.HasPermission("CanSeeAllOrders", null))
             {
                 return new HelloResponse
                 {

--- a/src/samples/ServiceAuthProvider.ServiceStack.SelfHost/ServiceAuthProvider.ServiceStack.SelfHost.csproj
+++ b/src/samples/ServiceAuthProvider.ServiceStack.SelfHost/ServiceAuthProvider.ServiceStack.SelfHost.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
@@ -16,6 +16,6 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ServiceStack.Razor" Version="4.0.56" />
+    <PackageReference Include="ServiceStack.Razor" Version="5.4.0" />
   </ItemGroup>
 </Project>

--- a/src/samples/UserAuthProvider.ServiceStack.Core.SelfHost/UserAuthProvider.ServiceStack.Core.SelfHost.csproj
+++ b/src/samples/UserAuthProvider.ServiceStack.Core.SelfHost/UserAuthProvider.ServiceStack.Core.SelfHost.csproj
@@ -1,12 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>UserAuthProvider.ServiceStack.Core.SelfHost</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>UserAuthProvider.ServiceStack.Core.SelfHost</PackageId>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <PackageTargetFallback>$(PackageTargetFallback);dotnet5.6;portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 
@@ -21,11 +20,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="2.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.4" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.0.2" />
-    <PackageReference Include="ServiceStack.Mvc.Core" Version="1.0.33" />
+    <PackageReference Include="ServiceStack.Mvc.Core" Version="5.4.00" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
   </ItemGroup>

--- a/src/samples/UserAuthProvider.ServiceStack.SelfHost/UserAuthProvider.ServiceStack.SelfHost.csproj
+++ b/src/samples/UserAuthProvider.ServiceStack.SelfHost/UserAuthProvider.ServiceStack.SelfHost.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
@@ -16,6 +16,6 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ServiceStack.Razor" Version="4.0.56" />
+    <PackageReference Include="ServiceStack.Razor" Version="5.4.00" />
   </ItemGroup>
 </Project>

--- a/src/test/IdentityServer3.Contrib.ServiceStack.Tests/IdentityServer3.Contrib.ServiceStack.Tests.csproj
+++ b/src/test/IdentityServer3.Contrib.ServiceStack.Tests/IdentityServer3.Contrib.ServiceStack.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\IdentityServer3.Contrib.ServiceStack\IdentityServer3.Contrib.ServiceStack.csproj" />

--- a/src/test/ServiceStack.Authentication.IdentityServer.Tests/ServiceStack.Authentication.IdentityServer.Tests.csproj
+++ b/src/test/ServiceStack.Authentication.IdentityServer.Tests/ServiceStack.Authentication.IdentityServer.Tests.csproj
@@ -1,11 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>ServiceStack.Authentication.IdentityServer.Tests</AssemblyName>
     <PackageId>ServiceStack.Authentication.IdentityServer.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR moves the project to using ServiceStack 5.4. 

Thi required retargeting projects at netstandard2.0/netcoreapp2.0/net462.
All #if pragmas for dotnet framework versions removed as dotnet 4.6.2 is actually fully netstandard2.0 compliant.

Closes #15 